### PR TITLE
Link to npmcharts.com for downloads badge?

### DIFF
--- a/templates/badges.jade
+++ b/templates/badges.jade
@@ -27,7 +27,7 @@ mixin badge-coverage(repo)
     +badge('/coveralls/' + repo)
 
 mixin badge-downloads(npm)
-  a(href='https://npmjs.org/package/' + npm)
+  a(href='https://npmcharts.com/compare/' + npm + '?minimal=true')
     +badge('/npm/dm/' + npm)
 
 mixin badge-gittip(user)


### PR DESCRIPTION
Hi there,

Apologies for being presumptuous in opening the PR, would have opened an issue to gauge interest first

I wanted to see if you might be interested in linking to my website npmcharts.com for the downloads badge?

e.g. the page for rc-dropdown would be https://npmcharts.com/compare/rc-dropdown?minimal=true and it'd show this:

![screencapture-npmcharts-compare-rc-dropdown-1505330368132](https://user-images.githubusercontent.com/743976/30396233-f3d81d9e-9896-11e7-91f0-2f802650bab9.png)

