### PR TITLE
fix: correct Cascader homepage link

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,6 +39,7 @@ projects:
      repo: react-component/checkbox
  - '@rc-component/cascader':
      repo: react-component/cascader
+     homepage: https://react-component.github.io/cascader
  - '@rc-component/collapse':
      repo: react-component/collapse
  - '@rc-component/drawer':

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
             <tr>
               <td><a href="https://github.com/react-component/cascader">@rc-component/cascader</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/cascader">@rc-component/cascader</a>
+              <td><a href="https://react-component.github.io/cascader">@rc-component/cascader</a>
               </td>
               <td>
               </td>

--- a/templates/projects.jade
+++ b/templates/projects.jade
@@ -35,7 +35,7 @@ mixin project(project)
   a(title=project.description, href='https://github.com/' + project.repo)= project.name
 
 mixin homepage(project)
-  a(title=project.description, href='http://react-component.github.io/' + project.name.replace(/^rc-/,''))= project.name
+  a(title=project.description, href=project.homepage || 'http://react-component.github.io/' + project.name.replace(/^rc-/,''))= project.name
 
 mixin maintainer(person)
   if typeof(person) === 'object' && person != null


### PR DESCRIPTION
## Summary

- add an explicit homepage override for Cascader
- prefer explicit homepage values in the badgeboard template
- regenerate the Cascader entry in `index.html`

## Root cause

The badgeboard derived the homepage path from the package display name. After `rc-cascader` became `@rc-component/cascader`, it generated `/@rc-component/cascader` even though the GitHub Pages site remains under `/cascader`.

## Validation

- confirmed the generated Cascader link is `https://react-component.github.io/cascader`
- confirmed the target resolves successfully with HTTP 200
- confirmed the branch is one commit ahead and changes only `config.yaml`, `templates/projects.jade`, and the generated `index.html`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 更新 `@rc-component/cascader` 的项目主页链接，改用正确的 HTTPS 地址。
  * 项目主页链接现可优先使用配置的自定义地址，未配置时仍保留默认链接规则。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->