### PR TITLE
fix: use repository names for homepage links

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
             <tr>
               <td><a href="https://github.com/react-component/checkbox">@rc-component/checkbox</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/checkbox">@rc-component/checkbox</a>
+              <td><a href="https://react-component.github.io/checkbox">@rc-component/checkbox</a>
               </td>
               <td>
               </td>
@@ -87,7 +87,7 @@
             <tr>
               <td><a href="https://github.com/react-component/collapse">@rc-component/collapse</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/collapse">@rc-component/collapse</a>
+              <td><a href="https://react-component.github.io/collapse">@rc-component/collapse</a>
               </td>
               <td>
               </td>
@@ -113,7 +113,7 @@
             <tr>
               <td><a href="https://github.com/react-component/context">@rc-component/context</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/context">@rc-component/context</a>
+              <td><a href="https://react-component.github.io/context">@rc-component/context</a>
               </td>
               <td>
               </td>
@@ -139,7 +139,7 @@
             <tr>
               <td><a href="https://github.com/react-component/dialog">@rc-component/dialog</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/dialog">@rc-component/dialog</a>
+              <td><a href="https://react-component.github.io/dialog">@rc-component/dialog</a>
               </td>
               <td>
               </td>
@@ -165,7 +165,7 @@
             <tr>
               <td><a href="https://github.com/react-component/drawer">@rc-component/drawer</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/drawer">@rc-component/drawer</a>
+              <td><a href="https://react-component.github.io/drawer">@rc-component/drawer</a>
               </td>
               <td>
               </td>
@@ -191,7 +191,7 @@
             <tr>
               <td><a href="https://github.com/react-component/dropdown">@rc-component/dropdown</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/dropdown">@rc-component/dropdown</a>
+              <td><a href="https://react-component.github.io/dropdown">@rc-component/dropdown</a>
               </td>
               <td>
               </td>
@@ -217,7 +217,7 @@
             <tr>
               <td><a href="https://github.com/react-component/footer">@rc-component/footer</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/footer">@rc-component/footer</a>
+              <td><a href="https://react-component.github.io/footer">@rc-component/footer</a>
               </td>
               <td>
               </td>
@@ -243,7 +243,7 @@
             <tr>
               <td><a href="https://github.com/react-component/form">@rc-component/form</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/form">@rc-component/form</a>
+              <td><a href="https://react-component.github.io/form">@rc-component/form</a>
               </td>
               <td>
               </td>
@@ -269,7 +269,7 @@
             <tr>
               <td><a href="https://github.com/react-component/image">@rc-component/image</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/image">@rc-component/image</a>
+              <td><a href="https://react-component.github.io/image">@rc-component/image</a>
               </td>
               <td>
               </td>
@@ -295,7 +295,7 @@
             <tr>
               <td><a href="https://github.com/react-component/input">@rc-component/input</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/input">@rc-component/input</a>
+              <td><a href="https://react-component.github.io/input">@rc-component/input</a>
               </td>
               <td>
               </td>
@@ -321,7 +321,7 @@
             <tr>
               <td><a href="https://github.com/react-component/input-number">@rc-component/input-number</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/input-number">@rc-component/input-number</a>
+              <td><a href="https://react-component.github.io/input-number">@rc-component/input-number</a>
               </td>
               <td>
               </td>
@@ -347,7 +347,7 @@
             <tr>
               <td><a href="https://github.com/react-component/mentions">@rc-component/mentions</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/mentions">@rc-component/mentions</a>
+              <td><a href="https://react-component.github.io/mentions">@rc-component/mentions</a>
               </td>
               <td>
               </td>
@@ -373,7 +373,7 @@
             <tr>
               <td><a href="https://github.com/react-component/menu">@rc-component/menu</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/menu">@rc-component/menu</a>
+              <td><a href="https://react-component.github.io/menu">@rc-component/menu</a>
               </td>
               <td>
               </td>
@@ -399,7 +399,7 @@
             <tr>
               <td><a href="https://github.com/react-component/mini-decimal">@rc-component/mini-decimal</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/mini-decimal">@rc-component/mini-decimal</a>
+              <td><a href="https://react-component.github.io/mini-decimal">@rc-component/mini-decimal</a>
               </td>
               <td>
               </td>
@@ -425,7 +425,7 @@
             <tr>
               <td><a href="https://github.com/react-component/motion">@rc-component/motion</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/motion">@rc-component/motion</a>
+              <td><a href="https://react-component.github.io/motion">@rc-component/motion</a>
               </td>
               <td>
               </td>
@@ -451,7 +451,7 @@
             <tr>
               <td><a href="https://github.com/react-component/mutate-observer">@rc-component/mutate-observer</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/mutate-observer">@rc-component/mutate-observer</a>
+              <td><a href="https://react-component.github.io/mutate-observer">@rc-component/mutate-observer</a>
               </td>
               <td>
               </td>
@@ -477,7 +477,7 @@
             <tr>
               <td><a href="https://github.com/react-component/notification">@rc-component/notification</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/notification">@rc-component/notification</a>
+              <td><a href="https://react-component.github.io/notification">@rc-component/notification</a>
               </td>
               <td>
               </td>
@@ -503,7 +503,7 @@
             <tr>
               <td><a href="https://github.com/react-component/overflow">@rc-component/overflow</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/overflow">@rc-component/overflow</a>
+              <td><a href="https://react-component.github.io/overflow">@rc-component/overflow</a>
               </td>
               <td>
               </td>
@@ -529,7 +529,7 @@
             <tr>
               <td><a href="https://github.com/react-component/pagination">@rc-component/pagination</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/pagination">@rc-component/pagination</a>
+              <td><a href="https://react-component.github.io/pagination">@rc-component/pagination</a>
               </td>
               <td>
               </td>
@@ -555,7 +555,7 @@
             <tr>
               <td><a href="https://github.com/react-component/picker">@rc-component/picker</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/picker">@rc-component/picker</a>
+              <td><a href="https://react-component.github.io/picker">@rc-component/picker</a>
               </td>
               <td>
               </td>
@@ -581,7 +581,7 @@
             <tr>
               <td><a href="https://github.com/react-component/portal">@rc-component/portal</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/portal">@rc-component/portal</a>
+              <td><a href="https://react-component.github.io/portal">@rc-component/portal</a>
               </td>
               <td>
               </td>
@@ -607,7 +607,7 @@
             <tr>
               <td><a href="https://github.com/react-component/progress">@rc-component/progress</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/progress">@rc-component/progress</a>
+              <td><a href="https://react-component.github.io/progress">@rc-component/progress</a>
               </td>
               <td>
               </td>
@@ -633,7 +633,7 @@
             <tr>
               <td><a href="https://github.com/react-component/resize-observer">@rc-component/resize-observer</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/resize-observer">@rc-component/resize-observer</a>
+              <td><a href="https://react-component.github.io/resize-observer">@rc-component/resize-observer</a>
               </td>
               <td>
               </td>
@@ -659,7 +659,7 @@
             <tr>
               <td><a href="https://github.com/react-component/resize-observer">@rc-component/resize-observer</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/resize-observer">@rc-component/resize-observer</a>
+              <td><a href="https://react-component.github.io/resize-observer">@rc-component/resize-observer</a>
               </td>
               <td>
               </td>
@@ -685,7 +685,7 @@
             <tr>
               <td><a href="https://github.com/react-component/segmented">@rc-component/segmented</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/segmented">@rc-component/segmented</a>
+              <td><a href="https://react-component.github.io/segmented">@rc-component/segmented</a>
               </td>
               <td>
               </td>
@@ -711,7 +711,7 @@
             <tr>
               <td><a href="https://github.com/react-component/select">@rc-component/select</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/select">@rc-component/select</a>
+              <td><a href="https://react-component.github.io/select">@rc-component/select</a>
               </td>
               <td>
               </td>
@@ -737,7 +737,7 @@
             <tr>
               <td><a href="https://github.com/react-component/slider">@rc-component/slider</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/slider">@rc-component/slider</a>
+              <td><a href="https://react-component.github.io/slider">@rc-component/slider</a>
               </td>
               <td>
               </td>
@@ -763,7 +763,7 @@
             <tr>
               <td><a href="https://github.com/react-component/steps">@rc-component/steps</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/steps">@rc-component/steps</a>
+              <td><a href="https://react-component.github.io/steps">@rc-component/steps</a>
               </td>
               <td>
               </td>
@@ -789,7 +789,7 @@
             <tr>
               <td><a href="https://github.com/react-component/switch">@rc-component/switch</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/switch">@rc-component/switch</a>
+              <td><a href="https://react-component.github.io/switch">@rc-component/switch</a>
               </td>
               <td>
               </td>
@@ -815,7 +815,7 @@
             <tr>
               <td><a href="https://github.com/react-component/table">@rc-component/table</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/table">@rc-component/table</a>
+              <td><a href="https://react-component.github.io/table">@rc-component/table</a>
               </td>
               <td>
               </td>
@@ -841,7 +841,7 @@
             <tr>
               <td><a href="https://github.com/react-component/tabs">@rc-component/tabs</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/tabs">@rc-component/tabs</a>
+              <td><a href="https://react-component.github.io/tabs">@rc-component/tabs</a>
               </td>
               <td>
               </td>
@@ -867,7 +867,7 @@
             <tr>
               <td><a href="https://github.com/react-component/textarea">@rc-component/textarea</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/textarea">@rc-component/textarea</a>
+              <td><a href="https://react-component.github.io/textarea">@rc-component/textarea</a>
               </td>
               <td>
               </td>
@@ -893,7 +893,7 @@
             <tr>
               <td><a href="https://github.com/react-component/tooltip">@rc-component/tooltip</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/tooltip">@rc-component/tooltip</a>
+              <td><a href="https://react-component.github.io/tooltip">@rc-component/tooltip</a>
               </td>
               <td>
               </td>
@@ -919,7 +919,7 @@
             <tr>
               <td><a href="https://github.com/react-component/tour">@rc-component/tour</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/tour">@rc-component/tour</a>
+              <td><a href="https://react-component.github.io/tour">@rc-component/tour</a>
               </td>
               <td>
               </td>
@@ -945,7 +945,7 @@
             <tr>
               <td><a href="https://github.com/react-component/tree">@rc-component/tree</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/tree">@rc-component/tree</a>
+              <td><a href="https://react-component.github.io/tree">@rc-component/tree</a>
               </td>
               <td>
               </td>
@@ -971,7 +971,7 @@
             <tr>
               <td><a href="https://github.com/react-component/tree-select">@rc-component/tree-select</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/tree-select">@rc-component/tree-select</a>
+              <td><a href="https://react-component.github.io/tree-select">@rc-component/tree-select</a>
               </td>
               <td>
               </td>
@@ -997,7 +997,7 @@
             <tr>
               <td><a href="https://github.com/react-component/trigger">@rc-component/trigger</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/trigger">@rc-component/trigger</a>
+              <td><a href="https://react-component.github.io/trigger">@rc-component/trigger</a>
               </td>
               <td>
               </td>
@@ -1023,7 +1023,7 @@
             <tr>
               <td><a href="https://github.com/react-component/upload">@rc-component/upload</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/upload">@rc-component/upload</a>
+              <td><a href="https://react-component.github.io/upload">@rc-component/upload</a>
               </td>
               <td>
               </td>
@@ -1049,7 +1049,7 @@
             <tr>
               <td><a href="https://github.com/react-component/util">@rc-component/util</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/util">@rc-component/util</a>
+              <td><a href="https://react-component.github.io/util">@rc-component/util</a>
               </td>
               <td>
               </td>
@@ -1075,7 +1075,7 @@
             <tr>
               <td><a href="https://github.com/react-component/virtual-list">@rc-component/virtual-list</a>
               </td>
-              <td><a href="http://react-component.github.io/@rc-component/virtual-list">@rc-component/virtual-list</a>
+              <td><a href="https://react-component.github.io/virtual-list">@rc-component/virtual-list</a>
               </td>
               <td>
               </td>
@@ -1101,7 +1101,7 @@
             <tr>
               <td><a href="https://github.com/yiminghe/async-validator">async-validator</a>
               </td>
-              <td><a href="http://react-component.github.io/async-validator">async-validator</a>
+              <td><a href="https://react-component.github.io/async-validator">async-validator</a>
               </td>
               <td>
               </td>
@@ -1127,7 +1127,7 @@
             <tr>
               <td><a href="https://github.com/yiminghe/dom-align">dom-align</a>
               </td>
-              <td><a href="http://react-component.github.io/dom-align">dom-align</a>
+              <td><a href="https://react-component.github.io/dom-align">dom-align</a>
               </td>
               <td>
               </td>

--- a/templates/projects.jade
+++ b/templates/projects.jade
@@ -35,7 +35,7 @@ mixin project(project)
   a(title=project.description, href='https://github.com/' + project.repo)= project.name
 
 mixin homepage(project)
-  a(title=project.description, href=project.homepage || 'http://react-component.github.io/' + project.name.replace(/^rc-/,''))= project.name
+  a(title=project.description, href=project.homepage || 'https://react-component.github.io/' + project.repo.split('/').pop())= project.name
 
 mixin maintainer(person)
   if typeof(person) === 'object' && person != null


### PR DESCRIPTION
## Summary
- derive default homepage paths from repository names
- regenerate Badgeboard links for scoped RC packages
- use HTTPS for generated GitHub Pages URLs

## Verification
- `@rc-component/collapse` links to `https://react-component.github.io/collapse`
- no generated link contains `/@rc-component/`
- Cascader remains `https://react-component.github.io/cascader`