### PR TITLE
fix: link Form to the field-form repository

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -87,7 +87,7 @@ projects:
  - '@rc-component/trigger':
      repo: react-component/trigger
  - '@rc-component/form':
-     repo: react-component/form
+     repo: react-component/field-form
  - '@rc-component/tree-select':
      repo: react-component/tree-select
  - '@rc-component/util':

--- a/index.html
+++ b/index.html
@@ -241,13 +241,13 @@
               </td>
             </tr>
             <tr>
-              <td><a href="https://github.com/react-component/form">@rc-component/form</a>
+              <td><a href="https://github.com/react-component/field-form">@rc-component/form</a>
               </td>
-              <td><a href="https://react-component.github.io/form">@rc-component/form</a>
+              <td><a href="https://react-component.github.io/field-form">@rc-component/form</a>
               </td>
               <td>
               </td>
-              <td><a href="https://github.com/react-component/form"><img src="https://flat.badgen.net/github/stars/react-component/form"/></a>
+              <td><a href="https://github.com/react-component/field-form"><img src="https://flat.badgen.net/github/stars/react-component/field-form"/></a>
               </td>
               <td><a href="https://npmjs.org/package/@rc-component/form"><img src="https://flat.badgen.net/npm/dm/@rc-component/form"/></a>
               </td>
@@ -257,13 +257,13 @@
               </td>
               <td><a href="https://packagephobia.now.sh/result?p=@rc-component/form"><img src="https://flat.badgen.net/packagephobia/install/@rc-component/form"/></a>
               </td>
-              <td><a href="https://codecov.io/gh/react-component/form"><img src="https://flat.badgen.net/codecov/c/github/react-component/form/master"/></a>
+              <td><a href="https://codecov.io/gh/react-component/field-form"><img src="https://flat.badgen.net/codecov/c/github/react-component/field-form/master"/></a>
               </td>
-              <td><a href="https://github.com/react-component/form/pulls"><img src="https://flat.badgen.net/github/last-commit/react-component/form"/></a>
+              <td><a href="https://github.com/react-component/field-form/pulls"><img src="https://flat.badgen.net/github/last-commit/react-component/field-form"/></a>
               </td>
-              <td><a href="https://github.com/react-component/form/issues"><img src="https://flat.badgen.net/github/open-issues/react-component/form"/></a>
+              <td><a href="https://github.com/react-component/field-form/issues"><img src="https://flat.badgen.net/github/open-issues/react-component/field-form"/></a>
               </td>
-              <td><a href="https://github.com/react-component/form/pulls"><img src="https://flat.badgen.net/github/open-prs/react-component/form"/></a>
+              <td><a href="https://github.com/react-component/field-form/pulls"><img src="https://flat.badgen.net/github/open-prs/react-component/field-form"/></a>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
## Summary
- map `@rc-component/form` to `react-component/field-form`
- regenerate its repository, badge, and homepage links

## Root cause
The scoped Form package replaced the old `rc-form` package, but Badgeboard still mapped it to the legacy `react-component/form` repository.

## Verification
- repository link is `https://github.com/react-component/field-form`
- homepage link is `https://react-component.github.io/field-form`
- npm badges remain scoped to `@rc-component/form`